### PR TITLE
Pin cucumber version (Fix #85)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brine (0.4.0)
-      cucumber
+      cucumber (~> 2.4)
       faraday
       faraday_middleware
       jsonpath
@@ -24,9 +24,9 @@ GEM
     builder (3.2.3)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
-    coderay (1.1.1)
+    coderay (1.1.2)
     contracts (0.16.0)
-    cucumber (2.4.0)
+    cucumber (2.99.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
       cucumber-wire (~> 0.0.1)
@@ -40,7 +40,7 @@ GEM
     diff-lcs (1.3)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.11.0.1)
+    faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.18)
     formatador (0.2.5)
@@ -59,7 +59,7 @@ GEM
       cucumber (~> 2.0)
       guard-compat (~> 1.0)
       nenv (~> 0.1)
-    jsonpath (0.8.5)
+    jsonpath (0.8.10)
       multi_json
     jwt (1.5.6)
     listen (3.1.5)
@@ -67,8 +67,8 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     lumberjack (1.0.12)
-    method_source (0.8.2)
-    multi_json (1.12.1)
+    method_source (0.9.0)
+    multi_json (1.12.2)
     multi_test (0.1.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -83,32 +83,30 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    pry (0.10.4)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
+      method_source (~> 0.9.0)
     rack (2.0.3)
-    rake (12.0.0)
-    rb-fsevent (0.9.8)
+    rake (12.3.0)
+    rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
     ruby_dep (1.5.0)
     shellany (0.0.1)
-    slop (3.6.0)
-    thor (0.19.4)
+    thor (0.20.0)
 
 PLATFORMS
   ruby
@@ -122,4 +120,4 @@ DEPENDENCIES
   rake!
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/brine.gemspec
+++ b/brine.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_runtime_dependency   'cucumber'
+  s.add_runtime_dependency   'cucumber', '~> 2.4'
   s.add_runtime_dependency   'mustache'
   s.add_runtime_dependency   'oauth2'
   s.add_runtime_dependency   'rspec'


### PR DESCRIPTION
This doesn't seem strictly necessary anymore as it must have been fixed in some upstream dependency, but it's good for safety.